### PR TITLE
Implement cycle status command for admins

### DIFF
--- a/backend/src/bot/keyboards/cycle_list_keyboard.py
+++ b/backend/src/bot/keyboards/cycle_list_keyboard.py
@@ -1,0 +1,15 @@
+from aiogram.types import InlineKeyboardButton, InlineKeyboardMarkup
+from typing import List
+
+from ...storage.models import FeedbackCycle
+from ...services.employee_service import EmployeeService
+
+
+def get_cycle_list_keyboard(cycles: List[FeedbackCycle], employee_service: EmployeeService) -> InlineKeyboardMarkup:
+    """Generate a keyboard with buttons for each cycle."""
+    buttons = []
+    for cycle in sorted(cycles, key=lambda c: c.created_at, reverse=True):
+        target = employee_service.find_by_id(cycle.target_employee_id)
+        text = target.full_name if target else cycle.id
+        buttons.append([InlineKeyboardButton(text=text, callback_data=f"cycle_status:{cycle.id}")])
+    return InlineKeyboardMarkup(inline_keyboard=buttons)

--- a/backend/src/services/cycle_service.py
+++ b/backend/src/services/cycle_service.py
@@ -76,6 +76,20 @@ class CycleService:
             logger.warning(f"Cycle with id {cycle_id} not found in Redis.")
         return cycle
 
+    async def get_all_cycles(self) -> list[FeedbackCycle]:
+        """Returns all cycles stored in Redis."""
+        keys = await self._redis.get_keys_by_pattern("cycle:*")
+        cycles = []
+        for key in keys:
+            cycle = await self._redis.get_model(key, FeedbackCycle)
+            if cycle:
+                cycles.append(cycle)
+        return cycles
+
+    async def save_cycle(self, cycle: FeedbackCycle) -> None:
+        """Persists the updated cycle back to Redis."""
+        await self._redis.set_model(f"cycle:{cycle.id}", cycle)
+
     async def send_invitation(
         self,
         bot: Bot,


### PR DESCRIPTION
## Summary
- allow admins to view cycle progress or reports
- list cycles via inline keyboard
- show progress for active cycles
- generate AI summary when cycle finished

## Testing
- `ruff check .`
- `mypy backend/src` *(fails: import stubs missing)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685fa7324c908330b7c62c4a936c319a