### PR TITLE
Fix markdown display in reports

### DIFF
--- a/backend/src/bot/handlers/admin.py
+++ b/backend/src/bot/handlers/admin.py
@@ -312,7 +312,7 @@ async def cmd_finish_cycle(
 
     if was_closed:
         report = await report_service.generate_report_for_cycle(cycle)
-        await message.answer(report, disable_web_page_preview=True)
+        await message.answer(report, disable_web_page_preview=True, parse_mode="Markdown")
     else:
         await message.answer(f"⚠️ Не удалось завершить цикл <code>{cycle_id}</code>. Возможно, он уже был закрыт другим администратором.")
 
@@ -339,7 +339,7 @@ async def finish_cycle_from_notification(
     if was_closed:
         await callback.answer()  # Acknowledge query to prevent timeout
         report = await report_service.generate_report_for_cycle(cycle)
-        await bot.send_message(callback.from_user.id, report, disable_web_page_preview=True)
+        await bot.send_message(callback.from_user.id, report, disable_web_page_preview=True, parse_mode="Markdown")
     else:
         await callback.message.edit_text(f"ℹ️ Цикл <code>{cycle.id}</code> уже был завершен.", reply_markup=None)
         await callback.answer("Цикл уже был закрыт.", show_alert=True)
@@ -376,4 +376,4 @@ async def show_cycle_status(
         report = await report_service.generate_report_for_cycle(cycle)
         cycle.status = "reported"
         await cycle_service.save_cycle(cycle)
-        await callback.message.edit_text(report, disable_web_page_preview=True)
+        await callback.message.edit_text(report, disable_web_page_preview=True, parse_mode="Markdown")

--- a/backend/src/services/report_service.py
+++ b/backend/src/services/report_service.py
@@ -132,8 +132,8 @@ class ReportService:
         """Generates a full summary report for a completed feedback cycle."""
         target_employee_name = await self._get_employee_full_name(cycle.target_employee_id)
         report_header = (
-            f"<b>Отчет по циклу 360° для {target_employee_name}</b>\n"
-            f"ID цикла: <code>{cycle.id}</code>\n"
+            f"**Отчет по циклу 360° для {target_employee_name}**\n"
+            f"ID цикла: `{cycle.id}`\n"
         )
 
         all_answers = await self._get_answers_for_cycle(cycle)
@@ -155,7 +155,7 @@ class ReportService:
             ai_summary = await self._summarize_with_ai(all_feedback_texts, target_employee_name)
         except RetryError as e:
             logger.error(f"Failed to get AI summary after multiple retries: {e}")
-            ai_summary = "<i>Не удалось сгенерировать AI-отчет из-за ошибки API.</i>"
+            ai_summary = "_Не удалось сгенерировать AI-отчет из-за ошибки API._"
 
         # TODO: Add calculation of average scores for competency questions
         # TODO: Add list of non-respondents


### PR DESCRIPTION
## Summary
- ensure generated report uses Markdown header
- send report messages with Markdown parse mode

## Testing
- `poetry run ruff check backend`
- `poetry run pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685fc4c94ae083308674c902ca256512